### PR TITLE
Fix macro_namespace arg is now used instead of deprecated packages arg in adapter.dispatch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   DBT_PROFILES_DIR: ./
-  DBT_VERSION: 0.19.1
+  DBT_VERSION: 0.19.2
   INTEGRATION_TEST_RELATION: test_data
   INTEGRATION_TEST_SCHEMA: dbt_profiler_integration_tests_postgres
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ One of the advantages of the `doc` approach over the `meta` approach is that it 
 
 ## Installation
 
-Check [dbt Hub](https://hub.getdbt.com/data-mie/dbt_profiler/latest/) for the latest installation instructions.
+`dbt-profiler` requires dbt version `>=0.19.2`. Check [dbt Hub](https://hub.getdbt.com/data-mie/dbt_profiler/latest/) for the latest installation instructions. 
 
 ## Supported adapters
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: "dbt_profiler"
 version: "0.1.0"
 
-require-dbt-version: ">=0.18.0"
+require-dbt-version: ">=0.19.2"
 config-version: 2
 
 target-path: "target"

--- a/macros/cross_db_utils.sql
+++ b/macros/cross_db_utils.sql
@@ -1,7 +1,7 @@
 {# type_string  -------------------------------------------------     #}
 
 {%- macro type_string() -%}
-  {{ return(adapter.dispatch("type_string", packages = ["dbt_profiler"])()) }}
+  {{ return(adapter.dispatch("type_string", macro_namespace="dbt_profiler")()) }}
 {%- endmacro -%}
 
 {%- macro default__type_string() -%}
@@ -16,7 +16,7 @@
 {# information_schema  -------------------------------------------------     #}
 
 {%- macro information_schema(relation) -%}
-  {{ return(adapter.dispatch("information_schema", packages = ["dbt_profiler"])(relation)) }}
+  {{ return(adapter.dispatch("information_schema", macro_namespace="dbt_profiler")(relation)) }}
 {%- endmacro -%}
 
 {%- macro default__information_schema(relation) -%}


### PR DESCRIPTION
Requires `dbt>=0.19.2`.