### PR TITLE
Redshift compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ One of the advantages of the `doc` approach over the `meta` approach is that it 
 
 ## Supported adapters
 
-`dbt-profiler` may work with unsupported adapters but they haven't been tested yet. I'll try and get around testing Redshift as soon as I get access to a cluster. If you've used `dbt-profiler` with any of the unsupported adapters I'd love to hear your feedback (e.g., create an issue, PR or hit me with with a DM on [dbt Slack](https://community.getdbt.com/)) 😊
+`dbt-profiler` may work with unsupported adapters but they haven't been tested yet. If you've used `dbt-profiler` with any of the unsupported adapters I'd love to hear your feedback (e.g., create an issue, PR or hit me with with a DM on [dbt Slack](https://community.getdbt.com/)) 😊
 
 ✅ PostgreSQL
 
@@ -75,7 +75,7 @@ One of the advantages of the `doc` approach over the `meta` approach is that it 
 
 ✅ Snowflake
 
-❌ Redshift
+✅ Redshift
 
 ❌ Apache Spark
 

--- a/macros/cross_db_utils.sql
+++ b/macros/cross_db_utils.sql
@@ -26,3 +26,33 @@
 {%- macro bigquery__information_schema(relation) -%}
   {{ adapter.quote(relation.schema) }}.INFORMATION_SCHEMA
 {%- endmacro -%}
+
+
+{# select_from_information_schema_columns  -------------------------------------------------     #}
+
+{%- macro select_from_information_schema_columns(relation, schema, relation_name) -%}
+  {{ return(adapter.dispatch("select_from_information_schema_columns", macro_namespace="dbt_profiler")(relation, schema, relation_name)) }}
+{%- endmacro -%}
+
+{%- macro default__select_from_information_schema_columns(relation, schema, relation_name) -%}
+  select
+    *
+  from {{ dbt_profiler.information_schema(relation) }}.COLUMNS
+  where lower(table_schema) = lower('{{ schema }}') 
+    and lower(table_name) = lower('{{ relation_name }}')
+{%- endmacro -%}
+
+{%- macro redshift__select_from_information_schema_columns(relation, schema, relation_name) -%}
+  select
+    attr.attname::varchar as column_name,
+    type.typname::varchar as data_type,
+    class.relname::varchar as table_name,
+    namespace.nspname::varchar as table_schema
+  from pg_catalog.pg_attribute as attr
+  join pg_catalog.pg_type as type on (attr.atttypid = type.oid)
+  join pg_catalog.pg_class as class on (attr.attrelid = class.oid)
+  join pg_catalog.pg_namespace as namespace on (class.relnamespace = namespace.oid)
+  where lower(table_schema) = lower('{{ schema }}') 
+    and lower(table_name) = lower('{{ relation_name }}')
+    and attr.attnum > 0
+{%- endmacro -%}


### PR DESCRIPTION
Redshift information schema cannot be joined with user defined tables due to information schema being accessible only from the Redshift leader node and not from compute nodes. This PR implements a workaround for Redshift that utilizes catalogue tables `pg_attribute`, `pg_type`, `pg_class` and `pg_namespace.`

Additional info:

* [Querying the catalog tables in Redshift](https://docs.aws.amazon.com/redshift/latest/dg/c_join_PG.html)