### PR TITLE
Add exclude_columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This macro returns a relation profile as an [agate.Table](https://agate.readthed
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
-* `exclude_metrics` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample.
+* `exclude_metrics` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample (ie, `"exclude_metrics:[index, primary_key]"`).
 
 ### Usage
 
@@ -309,6 +309,7 @@ This macro prints a relation profile as a Markdown table wrapped in a Jinja `doc
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
+* `exclude_metrics` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample (ie, `"exclude_metrics:[index, primary_key]"`).
 * `docs_name` (optional): `docs` macro name (default: `dbt_profiler__{{ relation_name }}`)
 * `max_rows` (optional): The maximum number of rows to display before truncating the data (default: `none` i.e., not truncated)
 * `max_columns` (optional): The maximum number of columns to display before truncating the data (default: `7`)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ This macro returns a relation profile as an [agate.Table](https://agate.readthed
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
+* `exclude_metrics` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample.
 
 ### Usage
 
@@ -167,6 +168,7 @@ This macro prints a relation profile as a Markdown table to `stdout`.
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
+* `exclude_metrics` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample (ie, `"exclude_metrics:[index, primary_key]"`).
 * `max_rows` (optional): The maximum number of rows to display before truncating the data (default: `none` i.e., not truncated)
 * `max_columns` (optional): The maximum number of columns to display before truncating the data (default: `7`)
 * `max_column_width` (optional): Truncate all columns to at most this width (default: `30`)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This macro returns a relation profile as an [agate.Table](https://agate.readthed
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
-* `exclude_metrics` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample (ie, `"exclude_metrics:[index, primary_key]"`).
+* `exclude_columns` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample (ie, `'exclude_columns:[index, primary_key]'`).
 
 ### Usage
 
@@ -161,14 +161,14 @@ Call this macro from another macro or dbt model:
 
 ## print_profile ([source](macros/print_profile.sql))
 
-This macro prints a relation profile as a Markdown table to `stdout`.
+This macro prints a relation profile as a Markdown table to `stdout`. 
 
 ### Arguments
 * `relation` (either `relation` or `relation_name` is required): Relation object
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
-* `exclude_metrics` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample (ie, `"exclude_metrics:[index, primary_key]"`).
+* `exclude_columns` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample (ie, `'exclude_columns:[index, primary_key]'`).
 * `max_rows` (optional): The maximum number of rows to display before truncating the data (default: `none` i.e., not truncated)
 * `max_columns` (optional): The maximum number of columns to display before truncating the data (default: `7`)
 * `max_column_width` (optional): Truncate all columns to at most this width (default: `30`)
@@ -202,6 +202,7 @@ This macro prints a relation schema YAML to `stdout` containing all columns and 
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
 * `model_description` (optional): Model description included in the schema (default: `""`)
 * `column_description` (optional): Column descriptions included in the schema (default: `""`)
+* `exclude_columns` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample (ie, `'exclude_columns:[index, primary_key]'`).
 
 ### Usage
 Call the macro as an [operation](https://docs.getdbt.com/docs/using-operations):
@@ -309,7 +310,7 @@ This macro prints a relation profile as a Markdown table wrapped in a Jinja `doc
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
-* `exclude_metrics` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample (ie, `"exclude_metrics:[index, primary_key]"`).
+* `exclude_columns` (optional): List of columns that should not be computed for the aggregates: avg, std_dev_population and std_dev_sample (ie, `'exclude_columns:[index, primary_key]'`).
 * `docs_name` (optional): `docs` macro name (default: `dbt_profiler__{{ relation_name }}`)
 * `max_rows` (optional): The maximum number of rows to display before truncating the data (default: `none` i.e., not truncated)
 * `max_columns` (optional): The maximum number of columns to display before truncating the data (default: `7`)
@@ -338,6 +339,8 @@ dbt run-operation print_profile_docs --args '{"relation_name": "customers"}'
 ```
 
 ### Contributions
+
+Note that the print_table() function that prints the output in the console does not work in dbt cloud.
 
 #### Added date type to tests, fix #37 Error when profiling integer after date after string columns
 

--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -2,8 +2,7 @@
 
 {% if execute %}
 
-  {% do dbt_profiler.assert_relation_exists(relation) %}
-
+  {% do dbt_profiler.assert_relation_exists(relation) %}  
   {{ log("Get columns in relation %s" | format(relation.include()), info=False) }}
   {%- set columns = adapter.get_columns_in_relation(relation) -%}
   {%- set column_names = columns | map(attribute="name") | list -%}
@@ -18,7 +17,7 @@
     {% do data_type_map.update({column_name: information_schema_data_types[loop.index-1]}) %}
   {% endfor %}
   {{ log("Column data types: " ~ data_type_map, info=False) }}
-
+  {% set exclude_columns = exclude_columns | map('lower') | list %}
   {% set profile_sql %}
     with column_profiles as (
       {% for column_name in column_names %}

--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -1,4 +1,4 @@
-{% macro get_profile(relation) %}
+{% macro get_profile(relation, exclude_metrics) %}
 
 {% if execute %}
   {% do dbt_profiler.assert_relation_exists(relation) %}
@@ -18,10 +18,13 @@
   {% endfor %}
   {{ log("Column data types: " ~ data_type_map, info=False) }}
 
+  {% set column_name_rep = dbt_utils.replace(column_name,"'","")%}
+  {% set exclude_metrics = exclude_metrics | map('lower') | list %}
   {% set profile_sql %}
     with column_profiles as (
       {% for column_name in column_names %}
         {% set data_type = data_type_map.get(column_name.lower(), "") %}
+
         select 
           lower('{{ column_name }}') as column_name,
           nullif(lower('{{ data_type }}'), '') as data_type,
@@ -32,9 +35,15 @@
           count(distinct {{ adapter.quote(column_name) }}) = count(*) as is_unique,
           {% if dbt_profiler.is_numeric_dtype(data_type) or dbt_profiler.is_date_or_time_dtype(data_type) %}cast(min({{ adapter.quote(column_name) }}) as {{ dbt_profiler.type_string() }}){% else %}null{% endif %} as min,
           {% if dbt_profiler.is_numeric_dtype(data_type) or dbt_profiler.is_date_or_time_dtype(data_type) %}cast(max({{ adapter.quote(column_name) }}) as {{ dbt_profiler.type_string() }}){% else %}null{% endif %} as max,
-          {% if dbt_profiler.is_numeric_dtype(data_type) %}avg({{ adapter.quote(column_name) }}){% else %}cast(null as numeric){% endif %} as avg,
-          {% if dbt_profiler.is_numeric_dtype(data_type) %}stddev_pop({{ adapter.quote(column_name) }}){% else %}cast(null as numeric){% endif %} as std_dev_population,
-          {% if dbt_profiler.is_numeric_dtype(data_type) %}stddev_samp({{ adapter.quote(column_name) }}){% else %}cast(null as numeric){% endif %} as std_dev_sample,
+          {% if column_name.lower() in exclude_metrics %}
+            NULL as avg,
+            NULL as std_dev_population,
+            NULL as std_dev_sample,
+          {% else %}
+            {% if dbt_profiler.is_numeric_dtype(data_type) %}avg({{ adapter.quote(column_name) }}){% else %}null{% endif %} as avg,
+            {% if dbt_profiler.is_numeric_dtype(data_type) %}stddev_pop({{ adapter.quote(column_name) }}){% else %}null{% endif %} as std_dev_population,
+            {% if dbt_profiler.is_numeric_dtype(data_type) %}stddev_samp({{ adapter.quote(column_name) }}){% else %}null{% endif %} as std_dev_sample,
+          {% endif %}
           cast(current_timestamp as {{ dbt_profiler.type_string() }}) as profiled_at,
           {{ loop.index }} as _column_position
         from {{ relation }}

--- a/macros/get_profile_table.sql
+++ b/macros/get_profile_table.sql
@@ -1,15 +1,17 @@
-{% macro get_profile_table(relation=none, relation_name=none, schema=none, database=none) %}
+{% macro get_profile_table(relation=none, relation_name=none, schema=none, database=none, exclude_metrics=none) %}
 
 {%- set relation = dbt_profiler.get_relation(
   relation=relation,
   relation_name=relation_name,
   schema=schema,
-  database=database
+  database=database,
+  exclude_metrics=exclude_metrics
 ) -%}
-{%- set profile_sql = dbt_profiler.get_profile(relation=relation) -%}
+{%- set profile_sql = dbt_profiler.get_profile(relation=relation.relation, exclude_metrics=relation.exclude_metrics) -%}
 {{ log(profile_sql, info=False) }}
 {% set results = run_query(profile_sql) %}
 {% set results = results.rename(results.column_names | map('lower')) %}
-{% do return(results) %}
 
+{% set results_res = {'results':results, 'exclude_metrics':exclude_metrics} %}
+{% do return(results_res) %}
 {% endmacro %}

--- a/macros/get_profile_table.sql
+++ b/macros/get_profile_table.sql
@@ -1,17 +1,17 @@
-{% macro get_profile_table(relation=none, relation_name=none, schema=none, database=none, exclude_metrics=none) %}
+{% macro get_profile_table(relation=none, relation_name=none, schema=none, database=none, exclude_columns=none) %}
 
 {%- set relation = dbt_profiler.get_relation(
   relation=relation,
   relation_name=relation_name,
   schema=schema,
-  database=database,
-  exclude_metrics=exclude_metrics
+  database=database
 ) -%}
-{%- set profile_sql = dbt_profiler.get_profile(relation=relation.relation, exclude_metrics=relation.exclude_metrics) -%}
-{{ log(profile_sql, info=False) }}
+
+{%- set profile_sql = dbt_profiler.get_profile(relation, exclude_columns=exclude_columns) -%}
+
 {% set results = run_query(profile_sql) %}
 {% set results = results.rename(results.column_names | map('lower')) %}
 
-{% set results_res = {'results':results, 'exclude_metrics':exclude_metrics} %}
-{% do return(results_res) %}
+{% do return(results) %}
+
 {% endmacro %}

--- a/macros/print_profile.sql
+++ b/macros/print_profile.sql
@@ -1,6 +1,6 @@
-{% macro print_profile(relation=none, relation_name=none, schema=none, database=none, exclude_metrics=none, max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
+{% macro print_profile(relation=none, relation_name=none, schema=none, database=none, exclude_columns=none, max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
 
-{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_metrics=exclude_metrics) -%}
+{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_columns=exclude_columns) -%}
 
 {% if execute %}
   {% do results.print_table(max_rows=max_rows, max_columns=max_columns, max_column_width=max_column_width, max_precision=max_precision) %}

--- a/macros/print_profile.sql
+++ b/macros/print_profile.sql
@@ -1,6 +1,6 @@
-{% macro print_profile(relation=none, relation_name=none, schema=none, database=none, max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
+{% macro print_profile(relation=none, relation_name=none, schema=none, database=none, exclude_metrics=none, max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
 
-{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database) -%}
+{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_metrics=exclude_metrics) -%}
 
 {% if execute %}
   {% do results.print_table(max_rows=max_rows, max_columns=max_columns, max_column_width=max_column_width, max_precision=max_precision) %}

--- a/macros/print_profile_docs.sql
+++ b/macros/print_profile_docs.sql
@@ -1,6 +1,7 @@
-{% macro print_profile_docs(relation=none, relation_name=none, docs_name=none, schema=none, database=none, max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
+{% macro print_profile_docs(relation=none, relation_name=none, docs_name=none, schema=none, database=none, exclude_metrics=none, max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
 
-{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database) -%}
+{%- set results_res = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_metrics=exclude_metrics) -%}
+{%- set results = results_res.results %} 
 
 {% if docs_name is none %}
   {% set docs_name = 'dbt_profiler__' + relation_name %}

--- a/macros/print_profile_docs.sql
+++ b/macros/print_profile_docs.sql
@@ -1,7 +1,6 @@
-{% macro print_profile_docs(relation=none, relation_name=none, docs_name=none, schema=none, database=none, exclude_metrics=none, max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
+{% macro print_profile_docs(relation=none, relation_name=none, docs_name=none, schema=none, database=none, exclude_columns=none, max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
 
-{%- set results_res = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_metrics=exclude_metrics) -%}
-{%- set results = results_res.results %} 
+{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_columns=exclude_columns) -%}
 
 {% if docs_name is none %}
   {% set docs_name = 'dbt_profiler__' + relation_name %}

--- a/macros/print_profile_schema.sql
+++ b/macros/print_profile_schema.sql
@@ -1,7 +1,8 @@
-{% macro print_profile_schema(relation=none, relation_name=none, schema=none, database=none, model_description="", column_description="") %}
+{% macro print_profile_schema(relation=none, relation_name=none, schema=none, database=none, exclude_metrics=none, model_description="", column_description="") %}
 
 {%- set column_dicts = [] -%}
-{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database) -%}
+{%- set results_res = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_metrics=exclude_metrics) -%}
+{%- set results=results_res.results %}}  
 
 {% if execute %}
   {% for row in results.rows %}

--- a/macros/print_profile_schema.sql
+++ b/macros/print_profile_schema.sql
@@ -1,8 +1,7 @@
-{% macro print_profile_schema(relation=none, relation_name=none, schema=none, database=none, exclude_metrics=none, model_description="", column_description="") %}
+{% macro print_profile_schema(relation=none, relation_name=none, schema=none, database=none, exclude_columns=none, model_description="", column_description="") %}
 
 {%- set column_dicts = [] -%}
-{%- set results_res = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_metrics=exclude_metrics) -%}
-{%- set results=results_res.results %}}  
+{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_columns=exclude_columns) -%}
 
 {% if execute %}
   {% for row in results.rows %}

--- a/macros/relation.sql
+++ b/macros/relation.sql
@@ -1,4 +1,4 @@
-{% macro get_relation(relation=none, relation_name=none, schema=none, database=none) %}
+{% macro get_relation(relation=none, relation_name=none, schema=none, database=none, exclude_metrics=none) %}
 
 {% if relation is none and relation_name is none %}
   {{ exceptions.raise_compiler_error("Either relation or relation_name must be specified.") }}
@@ -26,8 +26,9 @@
     {{ exceptions.raise_compiler_error("Relation " ~ adapter.quote(relation_name) ~ " does not exist or not authorized.") }}
   {% endif %}
 {% endif %}
+{% set relation_res = {'relation':relation, 'exclude_metrics':exclude_metrics} %}
 
-{% do return(relation) %}
+{% do return(relation_res) %}
 
 {% endmacro %}
 

--- a/macros/relation.sql
+++ b/macros/relation.sql
@@ -1,4 +1,4 @@
-{% macro get_relation(relation=none, relation_name=none, schema=none, database=none, exclude_metrics=none) %}
+{% macro get_relation(relation=none, relation_name=none, schema=none, database=none) %}
 
 {% if relation is none and relation_name is none %}
   {{ exceptions.raise_compiler_error("Either relation or relation_name must be specified.") }}
@@ -26,9 +26,8 @@
     {{ exceptions.raise_compiler_error("Relation " ~ adapter.quote(relation_name) ~ " does not exist or not authorized.") }}
   {% endif %}
 {% endif %}
-{% set relation_res = {'relation':relation, 'exclude_metrics':exclude_metrics} %}
 
-{% do return(relation_res) %}
+{% do return(relation) %}
 
 {% endmacro %}
 


### PR DESCRIPTION
## Description & motivation
<!---
Average, std_dev, don't need to be calculated for certain numeric columns. For instance, identifiers.
This PR adds an optional argument `exclude_columns` that takes an array as an input.

Columns in this array won't be included in the following calculations:
- avg
- std_dev_population
- std_dev_sample

It is called as follow:
`dbt run-operation get_profile --args '{"relation": "customers", "exclude_columns":'[customer_id,account_id]'}'`

-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [ ] Postgres
    - [ ] BigQuery
    - [ x] Snowflake
    - [ ] Redshift
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [ x] I have updated the README.md (if applicable)