### PR TITLE
Add exclude_measures macro argument for excluding measures from profiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   DBT_PROFILES_DIR: ./
-  DBT_VERSION: 1.0.0
   INTEGRATION_TEST_RELATION: test_data
   INTEGRATION_TEST_SCHEMA: dbt_profiler_integration_tests_postgres
   POSTGRES_HOST: postgres
@@ -48,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install dbt-postgres==${DBT_VERSION}
+          pip install dbt-postgres
           dbt deps
           dbt --version
 
@@ -82,7 +81,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install dbt-bigquery==${DBT_VERSION}
+          pip install dbt-bigquery
           dbt deps
           dbt --version
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@
 
 * `column_name`: Name of the column
 * `data_type`: Data type of the column
-* `not_null_proportion`: Proportion of column values that are not `NULL` (e.g., `0.62` means that 62% of the values are populated while 38% are `NULL`)
-* `distinct_proportion`: Proportion of unique column values (e.g., `1` means that 100% of the values are unique)
-* `distinct_count`: Count of unique column values
-* `is_unique`: True if all column values are unique
-* `min`*: Minimum column value
-* `max`*: Maximum column value
-* `avg`**: Average column value
-* `std_dev_population`**: Population standard deviation
-* `std_dev_sample`**: Sample standard deviation
+* `not_null_proportion`^: Proportion of column values that are not `NULL` (e.g., `0.62` means that 62% of the values are populated while 38% are `NULL`)
+* `distinct_proportion`^: Proportion of unique column values (e.g., `1` means that 100% of the values are unique)
+* `distinct_count`^: Count of unique column values
+* `is_unique`^: True if all column values are unique
+* `min`*^: Minimum column value
+* `max`*^: Maximum column value
+* `avg`**^: Average column value
+* `std_dev_population`**^: Population standard deviation
+* `std_dev_sample`**^: Sample standard deviation
 * `profiled_at`: Profile calculation date and time
 
 `*` numeric, date and time columns only
 `**` numeric columns only
+`^` can be excluded from the profile using `exclude_measures` argument
 
 ## Purpose 
 
@@ -116,6 +117,7 @@ This macro returns a relation profile as a SQL query that can be used in a dbt m
 
 ### Arguments
 * `relation` (required): [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) object
+* `exclude_measures` (optional): List of measures to exclude from the profile (default: `[]`)
 
 ### Usage
 
@@ -128,7 +130,7 @@ Use this macro in a dbt model, using a [ref()](https://docs.getdbt.com/reference
 Use this macro in a dbt model, using a [source()](https://docs.getdbt.com/reference/dbt-jinja-functions/source):
 
 ```sql
-{{ dbt_profiler.get_profile(relation=source("jaffle_shop","customers")) }}
+{{ dbt_profiler.get_profile(relation=source("jaffle_shop","customers"), exclude_measures=["std_dev_population", "std_dev_sample"]) }}
 ```
 
 To configure the macro to be called only when dbt is in [execute](https://docs.getdbt.com/reference/dbt-jinja-functions/execute) mode:
@@ -149,6 +151,7 @@ This macro returns a relation profile as an [agate.Table](https://agate.readthed
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
+* `exclude_measures` (optional): List of measures to exclude from the profile (default: `[]`)
 
 ### Usage
 
@@ -167,6 +170,7 @@ This macro prints a relation profile as a Markdown table to `stdout`.
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
+* `exclude_measures` (optional): List of measures to exclude from the profile (default: `[]`)
 * `max_rows` (optional): The maximum number of rows to display before truncating the data (default: `none` i.e., not truncated)
 * `max_columns` (optional): The maximum number of columns to display before truncating the data (default: `7`)
 * `max_column_width` (optional): Truncate all columns to at most this width (default: `30`)
@@ -198,6 +202,7 @@ This macro prints a relation schema YAML to `stdout` containing all columns and 
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
+* `exclude_measures` (optional): List of measures to exclude from the profile (default: `[]`)
 * `model_description` (optional): Model description included in the schema (default: `""`)
 * `column_description` (optional): Column descriptions included in the schema (default: `""`)
 
@@ -307,6 +312,7 @@ This macro prints a relation profile as a Markdown table wrapped in a Jinja `doc
 * `relation_name` (either `relation` or `relation_name` is required): Relation name
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
+* `exclude_measures` (optional): List of measures to exclude from the profile (default: `[]`)
 * `docs_name` (optional): `docs` macro name (default: `dbt_profiler__{{ relation_name }}`)
 * `max_rows` (optional): The maximum number of rows to display before truncating the data (default: `none` i.e., not truncated)
 * `max_columns` (optional): The maximum number of columns to display before truncating the data (default: `7`)

--- a/integration_tests/models/profile_exclude_measures.sql
+++ b/integration_tests/models/profile_exclude_measures.sql
@@ -1,0 +1,4 @@
+-- depends_on: {{ ref("test_data") }}
+{% if execute %}
+  {{ dbt_profiler.get_profile(relation=ref("test_data"), exclude_measures=["avg", "std_dev_population", "std_dev_sample"]) }}
+{% endif %}

--- a/macros/get_profile_table.sql
+++ b/macros/get_profile_table.sql
@@ -1,4 +1,4 @@
-{% macro get_profile_table(relation=none, relation_name=none, schema=none, database=none) %}
+{% macro get_profile_table(relation=none, relation_name=none, schema=none, database=none, exclude_measures=[]) %}
 
 {%- set relation = dbt_profiler.get_relation(
   relation=relation,
@@ -6,7 +6,7 @@
   schema=schema,
   database=database
 ) -%}
-{%- set profile_sql = dbt_profiler.get_profile(relation=relation) -%}
+{%- set profile_sql = dbt_profiler.get_profile(relation=relation, exclude_measures=exclude_measures) -%}
 {{ log(profile_sql, info=False) }}
 {% set results = run_query(profile_sql) %}
 {% set results = results.rename(results.column_names | map('lower')) %}

--- a/macros/print_profile.sql
+++ b/macros/print_profile.sql
@@ -1,6 +1,6 @@
-{% macro print_profile(relation=none, relation_name=none, schema=none, database=none, max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
+{% macro print_profile(relation=none, relation_name=none, schema=none, database=none, exclude_measures=[], max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
 
-{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database) -%}
+{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_measures=exclude_measures) -%}
 
 {% if execute %}
   {% do results.print_table(max_rows=max_rows, max_columns=max_columns, max_column_width=max_column_width, max_precision=max_precision) %}

--- a/macros/print_profile_docs.sql
+++ b/macros/print_profile_docs.sql
@@ -1,6 +1,6 @@
-{% macro print_profile_docs(relation=none, relation_name=none, docs_name=none, schema=none, database=none, max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
+{% macro print_profile_docs(relation=none, relation_name=none, docs_name=none, schema=none, database=none, exclude_measures=[], max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
 
-{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database) -%}
+{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_measures=exclude_measures) -%}
 
 {% if docs_name is none %}
   {% set docs_name = 'dbt_profiler__' + relation_name %}

--- a/macros/print_profile_schema.sql
+++ b/macros/print_profile_schema.sql
@@ -1,7 +1,7 @@
-{% macro print_profile_schema(relation=none, relation_name=none, schema=none, database=none, model_description="", column_description="") %}
+{% macro print_profile_schema(relation=none, relation_name=none, schema=none, database=none, exclude_measures=[], model_description="", column_description="") %}
 
 {%- set column_dicts = [] -%}
-{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database) -%}
+{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_measures=exclude_measures) -%}
 
 {% if execute %}
   {% for row in results.rows %}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [x] Postgres
    - [x] BigQuery
    - [x] Snowflake
    - [ ] Redshift
- [x] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [x] I have updated the README.md (if applicable)