### PR TITLE
Add database identifier to bigquery__information_schema macro

### DIFF
--- a/macros/cross_db_utils.sql
+++ b/macros/cross_db_utils.sql
@@ -47,7 +47,7 @@
 {%- endmacro -%}
 
 {%- macro bigquery__information_schema(relation) -%}
-  {{ adapter.quote(relation.schema) }}.INFORMATION_SCHEMA
+  {{ adapter.quote(relation.database) }}.{{ adapter.quote(relation.schema) }}.INFORMATION_SCHEMA
 {%- endmacro -%}
 
 


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [ ] Postgres
    - [ ] BigQuery
    - [ ] Snowflake
    - [ ] Redshift
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [ ] I have updated the README.md (if applicable)