### PR TITLE
Add `include_columns` and `exclude_columns` arguments to profiling macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ This macro returns a relation profile as a SQL query that can be used in a dbt m
 ### Arguments
 * `relation` (required): [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) object
 * `exclude_measures` (optional): List of measures to exclude from the profile (default: `[]`)
+* `include_columns` (optional): List of columns to include in the profile (default: `[]` i.e., all). Only one of `include_columns` and `exclude_columns` can be specified at a time.
+* `exclude_columns` (optional): List of columns to exclude from the profile (default: `[]`). Only one of `include_columns` and `exclude_columns` can be specified at a time.
 
 ### Usage
 
@@ -154,6 +156,8 @@ This macro returns a relation profile as an [agate.Table](https://agate.readthed
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
 * `exclude_measures` (optional): List of measures to exclude from the profile (default: `[]`)
+* `include_columns` (optional): List of columns to include in the profile (default: `[]` i.e., all). Only one of `include_columns` and `exclude_columns` can be specified at a time.
+* `exclude_columns` (optional): List of columns to exclude from the profile (default: `[]`). Only one of `include_columns` and `exclude_columns` can be specified at a time.
 
 ### Usage
 
@@ -173,6 +177,8 @@ This macro prints a relation profile as a Markdown table to `stdout`.
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
 * `exclude_measures` (optional): List of measures to exclude from the profile (default: `[]`)
+* `include_columns` (optional): List of columns to include in the profile (default: `[]` i.e., all). Only one of `include_columns` and `exclude_columns` can be specified at a time.
+* `exclude_columns` (optional): List of columns to exclude from the profile (default: `[]`). Only one of `include_columns` and `exclude_columns` can be specified at a time.
 * `max_rows` (optional): The maximum number of rows to display before truncating the data (default: `none` i.e., not truncated)
 * `max_columns` (optional): The maximum number of columns to display before truncating the data (default: `7`)
 * `max_column_width` (optional): Truncate all columns to at most this width (default: `30`)
@@ -205,6 +211,8 @@ This macro prints a relation schema YAML to `stdout` containing all columns and 
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
 * `exclude_measures` (optional): List of measures to exclude from the profile (default: `[]`)
+* `include_columns` (optional): List of columns to include in the profile (default: `[]` i.e., all). Only one of `include_columns` and `exclude_columns` can be specified at a time.
+* `exclude_columns` (optional): List of columns to exclude from the profile (default: `[]`). Only one of `include_columns` and `exclude_columns` can be specified at a time.
 * `model_description` (optional): Model description included in the schema (default: `""`)
 * `column_description` (optional): Column descriptions included in the schema (default: `""`)
 
@@ -315,6 +323,8 @@ This macro prints a relation profile as a Markdown table wrapped in a Jinja `doc
 * `schema` (optional): Schema where `relation_name` exists (default: `none` i.e., target schema)
 * `database` (optional): Database where `relation_name` exists (default: `none` i.e., target database)
 * `exclude_measures` (optional): List of measures to exclude from the profile (default: `[]`)
+* `include_columns` (optional): List of columns to include in the profile (default: `[]` i.e., all). Only one of `include_columns` and `exclude_columns` can be specified at a time.
+* `exclude_columns` (optional): List of columns to exclude from the profile (default: `[]`). Only one of `include_columns` and `exclude_columns` can be specified at a time.
 * `docs_name` (optional): `docs` macro name (default: `dbt_profiler__{{ relation_name }}`)
 * `max_rows` (optional): The maximum number of rows to display before truncating the data (default: `none` i.e., not truncated)
 * `max_columns` (optional): The maximum number of columns to display before truncating the data (default: `7`)

--- a/integration_tests/models/profile_exclude_columns.sql
+++ b/integration_tests/models/profile_exclude_columns.sql
@@ -1,0 +1,4 @@
+-- depends_on: {{ ref("test_data") }}
+{% if execute %}
+  {{ dbt_profiler.get_profile(relation=ref("test_data"), exclude_columns=["numeric_not_nullable"]) }}
+{% endif %}

--- a/integration_tests/models/profile_exclude_columns.sql
+++ b/integration_tests/models/profile_exclude_columns.sql
@@ -1,4 +1,8 @@
 -- depends_on: {{ ref("test_data") }}
 {% if execute %}
-  {{ dbt_profiler.get_profile(relation=ref("test_data"), exclude_columns=["numeric_not_nullable"]) }}
+  {%- set exclude_columns = ["numeric_not_nullable"] -%}
+  {%- if target.type == "snowflake" -%}
+    {%- set exclude_columns = exclude_columns | map("upper") | list -%}
+  {%- endif -%}
+  {{ dbt_profiler.get_profile(relation=ref("test_data"), exclude_columns=exclude_columns) }}
 {% endif %}

--- a/integration_tests/models/profile_exclude_columns.yml
+++ b/integration_tests/models/profile_exclude_columns.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+  - name: profile_exclude_columns
+    columns:
+      - name: column_name
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_in_set:
+              value_set: ["numeric_not_nullable"]

--- a/integration_tests/models/profile_exclude_measures.yml
+++ b/integration_tests/models/profile_exclude_measures.yml
@@ -1,0 +1,8 @@
+version: 2
+
+models:
+  - name: profile_exclude_measures
+    tests:
+      - dbt_expectations.expect_table_columns_to_not_contain_set:
+          column_list: ["avg", "std_dev_population", "std_dev_sample"]
+          transform: lower

--- a/integration_tests/models/profile_include_columns.sql
+++ b/integration_tests/models/profile_include_columns.sql
@@ -1,4 +1,8 @@
 -- depends_on: {{ ref("test_data") }}
 {% if execute %}
-  {{ dbt_profiler.get_profile(relation=ref("test_data"), include_columns=["numeric_not_nullable"]) }}
+  {%- set include_columns = ["numeric_not_nullable"] -%}
+  {%- if target.type == "snowflake" -%}
+    {%- set include_columns = include_columns | map("upper") | list -%}
+  {%- endif -%}
+  {{ dbt_profiler.get_profile(relation=ref("test_data"), include_columns=include_columns) }}
 {% endif %}

--- a/integration_tests/models/profile_include_columns.sql
+++ b/integration_tests/models/profile_include_columns.sql
@@ -1,0 +1,4 @@
+-- depends_on: {{ ref("test_data") }}
+{% if execute %}
+  {{ dbt_profiler.get_profile(relation=ref("test_data"), include_columns=["numeric_not_nullable"]) }}
+{% endif %}

--- a/integration_tests/models/profile_include_columns.yml
+++ b/integration_tests/models/profile_include_columns.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+  - name: profile_include_columns
+    columns:
+      - name: column_name
+        tests:
+          - accepted_values:
+              values: ["numeric_not_nullable"]

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,2 +1,4 @@
 packages:
   - local: ../
+  - package: calogica/dbt_expectations
+    version: [">=0.5.0", "<0.6.0"]

--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -50,13 +50,7 @@
   {{ log("Column data types: " ~ data_type_map, info=False) }}
 
   {% set profile_sql %}
-    with source_data as (
-      select
-        *
-      from {{ relation }}
-    ),
-
-    column_profiles as (
+    with column_profiles as (
       {% for column_name in profile_column_names %}
         {% set data_type = data_type_map.get(column_name.lower(), "") %}
         select 
@@ -94,7 +88,7 @@
           {%- endif %}
           cast(current_timestamp as {{ dbt_profiler.type_string() }}) as profiled_at,
           {{ loop.index }} as _column_position
-        from source_data
+        from {{ relation }}
 
         {% if not loop.last %}union all{% endif %}
       {% endfor %}

--- a/macros/get_profile_table.sql
+++ b/macros/get_profile_table.sql
@@ -1,4 +1,4 @@
-{% macro get_profile_table(relation=none, relation_name=none, schema=none, database=none, exclude_measures=[]) %}
+{% macro get_profile_table(relation=none, relation_name=none, schema=none, database=none, exclude_measures=[], include_columns=[], exclude_columns=[]) %}
 
 {%- set relation = dbt_profiler.get_relation(
   relation=relation,
@@ -6,7 +6,7 @@
   schema=schema,
   database=database
 ) -%}
-{%- set profile_sql = dbt_profiler.get_profile(relation=relation, exclude_measures=exclude_measures) -%}
+{%- set profile_sql = dbt_profiler.get_profile(relation=relation, exclude_measures=exclude_measures, include_columns=include_columns, exclude_columns=exclude_columns) -%}
 {{ log(profile_sql, info=False) }}
 {% set results = run_query(profile_sql) %}
 {% set results = results.rename(results.column_names | map('lower')) %}

--- a/macros/print_profile.sql
+++ b/macros/print_profile.sql
@@ -1,6 +1,6 @@
-{% macro print_profile(relation=none, relation_name=none, schema=none, database=none, exclude_measures=[], max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
+{% macro print_profile(relation=none, relation_name=none, schema=none, database=none, exclude_measures=[], include_columns=[], exclude_columns=[], max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
 
-{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_measures=exclude_measures) -%}
+{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_measures=exclude_measures, include_columns=include_columns, exclude_columns=exclude_columns) -%}
 
 {% if execute %}
   {% do results.print_table(max_rows=max_rows, max_columns=max_columns, max_column_width=max_column_width, max_precision=max_precision) %}

--- a/macros/print_profile_docs.sql
+++ b/macros/print_profile_docs.sql
@@ -1,6 +1,6 @@
-{% macro print_profile_docs(relation=none, relation_name=none, docs_name=none, schema=none, database=none, exclude_measures=[], max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
+{% macro print_profile_docs(relation=none, relation_name=none, docs_name=none, schema=none, database=none, exclude_measures=[], include_columns=[], exclude_columns=[], max_rows=none, max_columns=13, max_column_width=30, max_precision=none) %}
 
-{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_measures=exclude_measures) -%}
+{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_measures=exclude_measures, include_columns=include_columns, exclude_columns=exclude_columns) -%}
 
 {% if docs_name is none %}
   {% set docs_name = 'dbt_profiler__' + relation_name %}

--- a/macros/print_profile_schema.sql
+++ b/macros/print_profile_schema.sql
@@ -1,7 +1,7 @@
-{% macro print_profile_schema(relation=none, relation_name=none, schema=none, database=none, exclude_measures=[], model_description="", column_description="") %}
+{% macro print_profile_schema(relation=none, relation_name=none, schema=none, database=none, exclude_measures=[], include_columns=[], exclude_columns=[], model_description="", column_description="") %}
 
 {%- set column_dicts = [] -%}
-{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_measures=exclude_measures) -%}
+{%- set results = dbt_profiler.get_profile_table(relation=relation, relation_name=relation_name, schema=schema, database=database, exclude_measures=exclude_measures, include_columns=include_columns, exclude_columns=exclude_columns) -%}
 
 {% if execute %}
   {% for row in results.rows %}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [x] Postgres
    - [x] BigQuery
    - [x] Snowflake
    - [ ] Redshift
- [x] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [x] I have updated the README.md (if applicable)