### PR TITLE
Improve profiler performance in Snowflake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 dbt_modules/
+dbt_packages/
 logs/
 
 venv/

--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -50,7 +50,13 @@
   {{ log("Column data types: " ~ data_type_map, info=False) }}
 
   {% set profile_sql %}
-    with column_profiles as (
+    with source_data as (
+      select
+        *
+      from {{ relation }}
+    ),
+
+    column_profiles as (
       {% for column_name in profile_column_names %}
         {% set data_type = data_type_map.get(column_name.lower(), "") %}
         select 
@@ -88,7 +94,7 @@
           {%- endif %}
           cast(current_timestamp as {{ dbt_profiler.type_string() }}) as profiled_at,
           {{ loop.index }} as _column_position
-        from {{ relation }}
+        from source_data
 
         {% if not loop.last %}union all{% endif %}
       {% endfor %}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Improve profiler performance in Snowflake by reducing table scans using a single CTE from which column profiles are calculated.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [x] Postgres
    - [x] BigQuery
    - [x] Snowflake
    - [ ] Redshift
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [ ] I have updated the README.md (if applicable)