### PR TITLE
✨ Add Databricks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ One of the advantages of the `doc` approach over the `meta` approach is that it 
 
 ✅ Redshift
 
-❌ Apache Spark
+✅ Databricks
 
-❌ Databricks
+❌ Apache Spark
 
 ❌ Presto
 

--- a/macros/cross_db_utils.sql
+++ b/macros/cross_db_utils.sql
@@ -12,6 +12,10 @@
   string
 {%- endmacro -%}
 
+{%- macro databricks__type_string() -%}
+  string
+{%- endmacro -%}
+
 
 {# is_numeric_dtype  -------------------------------------------------     #}
 

--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -1,4 +1,10 @@
 {% macro get_profile(relation, exclude_measures=[], include_columns=[], exclude_columns=[]) %}
+  {{ return(adapter.dispatch("get_profile", macro_namespace="dbt_profiler")(relation, exclude_measures, include_columns, exclude_columns)) }}
+{% endmacro %}
+
+
+
+{% macro default__get_profile(relation, exclude_measures=[], include_columns=[], exclude_columns=[]) %}
 
 {%- if include_columns and exclude_columns -%}
     {{ exceptions.raise_compiler_error("Both include_columns and exclude_columns arguments were provided to the `get_profile` macro. Only one is allowed.") }}
@@ -110,6 +116,133 @@
     from column_profiles
     order by _column_position asc
   {% endset %}
+
+  {% do return(profile_sql) %}
+{% endif %}
+
+{% endmacro %}
+
+
+
+{% macro databricks__get_profile(relation, exclude_measures=[], include_columns=[], exclude_columns=[]) %}
+
+{%- if include_columns and exclude_columns -%}
+    {{ exceptions.raise_compiler_error("Both include_columns and exclude_columns arguments were provided to the `get_profile` macro. Only one is allowed.") }}
+{%- endif -%}
+
+{%- set all_measures = [
+  "row_count",
+  "not_null_proportion",
+  "distinct_proportion",
+  "distinct_count",
+  "is_unique",
+  "min",
+  "max",
+  "avg",
+  "std_dev_population",
+  "std_dev_sample"
+] -%}
+
+{%- set include_measures = all_measures | reject("in", exclude_measures) -%}
+
+{{ log("Include measures: " ~ include_measures, info=False) }}
+
+{% if execute %}
+  {% do dbt_profiler.assert_relation_exists(relation) %}
+
+  {{ log("Get columns in relation %s" | format(relation.include()), info=True) }}
+  {%- set relation_columns = adapter.get_columns_in_relation(relation) -%}
+  {%- set relation_column_names = relation_columns | map(attribute="name") | list -%}
+  {{ log("Relation columns: " ~ relation_column_names | join(', '), info=False) }}
+
+  {%- if include_columns -%}
+    {%- set profile_column_names = relation_column_names | select("in", include_columns) | list-%}
+  {%- elif exclude_columns -%}
+    {%- set profile_column_names = relation_column_names | reject("in", exclude_columns) | list -%}
+  {%- else -%}
+    {%- set profile_column_names = relation_column_names -%}
+  {%- endif -%}
+
+  {{ log("Profile columns: " ~ profile_column_names | join(', '), info=False) }}
+
+  {# Get column metadata. #}
+  {% call statement('table_metadata', fetch_result=True) -%}
+    describe table extended {{ relation.schema }}.{{ relation.identifier }}
+  {% endcall %}
+  {% set columns_metadata = load_result('table_metadata').table %}
+  {% set columns_metadata = columns_metadata.rename(columns_metadata.column_names | map('lower')) %}
+  
+  {% set data_types = columns_metadata.columns['data_type'].values() | map('lower') | list %}
+  {% set column_names = columns_metadata.columns['col_name'].values() | map('lower') | list %}
+  {% set data_type_map = {} %}
+  {% for column_name in column_names %}
+    {% do data_type_map.update({column_name: data_types[loop.index-1]}) %}
+  {% endfor %}
+  {{ log("Column data types: " ~ data_type_map, info=False) }}
+
+  {% set profile_sql %}
+    with source_data as (
+      select
+        *
+      from {{ relation }}
+    ),
+
+    column_profiles as (
+      {% for column_name in profile_column_names %}
+        {% set data_type = data_type_map.get(column_name.lower(), "") %}
+        select 
+          lower('{{ column_name }}') as column_name,
+          nullif(lower('{{ data_type }}'), '') as data_type,
+          {% if "row_count" not in exclude_measures -%}
+            cast(count(*) as numeric) as row_count,
+          {%- endif %}
+          {% if "not_null_proportion" not in exclude_measures -%}
+            sum(case when {{ adapter.quote(column_name) }} is null then 0 else 1 end) / cast(count(*) as numeric) as not_null_proportion,
+          {%- endif %}
+          {% if "distinct_proportion" not in exclude_measures -%}
+            count(distinct {{ adapter.quote(column_name) }}) / cast(count(*) as numeric) as distinct_proportion,
+          {%- endif %}
+          {% if "distinct_count" not in exclude_measures -%}
+            count(distinct {{ adapter.quote(column_name) }}) as distinct_count,
+          {%- endif %}
+          {% if "is_unique" not in exclude_measures -%}
+            count(distinct {{ adapter.quote(column_name) }}) = count(*) as is_unique,
+          {%- endif %}
+          {% if "min" not in exclude_measures -%}
+            {% if dbt_profiler.is_numeric_dtype(data_type) or dbt_profiler.is_date_or_time_dtype(data_type) %}cast(min({{ adapter.quote(column_name) }}) as {{ dbt_profiler.type_string() }}){% else %}null{% endif %} as min,
+          {%- endif %}
+          {% if "max" not in exclude_measures -%}
+            {% if dbt_profiler.is_numeric_dtype(data_type) or dbt_profiler.is_date_or_time_dtype(data_type) %}cast(max({{ adapter.quote(column_name) }}) as {{ dbt_profiler.type_string() }}){% else %}null{% endif %} as max,
+          {%- endif %}
+          {% if "avg" not in exclude_measures -%}
+            {% if dbt_profiler.is_numeric_dtype(data_type) %}avg({{ adapter.quote(column_name) }}){% else %}cast(null as numeric){% endif %} as avg,
+          {%- endif %}
+          {% if "std_dev_population" not in exclude_measures -%}
+            {% if dbt_profiler.is_numeric_dtype(data_type) %}stddev_pop({{ adapter.quote(column_name) }}){% else %}cast(null as numeric){% endif %} as std_dev_population,
+          {%- endif %}
+          {% if "std_dev_sample" not in exclude_measures -%}
+            {% if dbt_profiler.is_numeric_dtype(data_type) %}stddev_samp({{ adapter.quote(column_name) }}){% else %}cast(null as numeric){% endif %} as std_dev_sample,
+          {%- endif %}
+          cast(current_timestamp as {{ dbt_profiler.type_string() }}) as profiled_at,
+          {{ loop.index }} as _column_position
+        from source_data
+
+        {% if not loop.last %}union all{% endif %}
+      {% endfor %}
+    )
+
+    select
+      column_name,
+      data_type,
+      {% for measure in include_measures %}
+        {{ measure }},
+      {% endfor %}
+      profiled_at
+    from column_profiles
+    order by _column_position asc
+  {% endset %}
+
+  {# {{ print(profile_sql) }} #}
 
   {% do return(profile_sql) %}
 {% endif %}


### PR DESCRIPTION
## Description & motivation
Adds support for Databricks. 

Ideally this should be tested more thoroughly and refactored a bit so that the `get_profile` macro doesn't have as much code duplication but at least it seems to be working.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [ ] Postgres
    - [ ] BigQuery
    - [ ] Snowflake
    - [ ] Redshift
    - [x] Databricks (tested on a small table with only a subset of the data types)
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [x] I have updated the README.md (if applicable)