### PR TITLE
Feature: add `is_logical_dtype` and average for bool column

### DIFF
--- a/integration_tests/data/test_data.csv
+++ b/integration_tests/data/test_data.csv
@@ -1,6 +1,6 @@
-id,numeric_not_nullable,numeric_nullable,string_not_nullable,string_nullable,date_nullable
-1,1,1,one,one,2022-01-01
-2,2,,two,,2022-01-01
-3,3,3,three,three,
-4,2,,two,,
-5,1,1,one,one,2022-01-01
+id,numeric_not_nullable,numeric_nullable,string_not_nullable,string_nullable,date_nullable,bool_nullable
+1,1,1,one,one,2022-01-01,true
+2,2,,two,,2022-01-01,false
+3,3,3,three,three,,
+4,2,,two,,,true
+5,1,1,one,one,2022-01-01,true

--- a/integration_tests/models/profile.yml
+++ b/integration_tests/models/profile.yml
@@ -38,12 +38,12 @@ models:
       - name: avg
         tests:
           - not_null:
-              where: &column_is_numeric column_name not like 'string%' and column_name not like 'date%'
+              where: &column_is_numeric_or_bool column_name not like 'string%' and column_name not like 'date%'
 
       - name: min
         tests:
           - not_null:
-              where: &column_is_numeric_or_date column_name not like 'string%'
+              where: &column_is_numeric_or_date column_name not like 'string%' and column_name not like 'bool%'
 
       - name: max
         tests:
@@ -53,7 +53,7 @@ models:
       - name: std_dev_population
         tests:
           - not_null:
-              where: *column_is_numeric
+              where: &column_is_numeric column_name not like 'string%' and column_name not like 'date%' and column_name not like 'bool%'
 
       - name: std_dev_sample
         tests:

--- a/integration_tests/tests/test_print_profile_schema.sql
+++ b/integration_tests/tests/test_print_profile_schema.sql
@@ -12,7 +12,7 @@
     and actual_model_count == 1 
     and actual_relation_name == "test_data" 
     and actual_description == ""
-    and actual_column_count == 6
+    and actual_column_count == 7
   %}
   {% if not is_pass %}
     select 'fail'

--- a/macros/cross_db_utils.sql
+++ b/macros/cross_db_utils.sql
@@ -34,22 +34,16 @@
 {%- endmacro -%}
 
 
-{# is_bool_dtype  -------------------------------------------------     #}
+{# is_logical_dtype  -------------------------------------------------     #}
 
-{%- macro is_bool_dtype(dtype) -%}
-  {{ return(adapter.dispatch("is_bool_dtype", macro_namespace="dbt_profiler")(dtype)) }}
+{%- macro is_logical_dtype(dtype) -%}
+  {{ return(adapter.dispatch("is_logical_dtype", macro_namespace="dbt_profiler")(dtype)) }}
 {%- endmacro -%}
 
-{%- macro default__is_bool_dtype(dtype) -%}
+{%- macro default__is_logical_dtype(dtype) -%}
   {% set is_bool = dtype.startswith("bool") %}
   {% do return(is_bool) %}
 {%- endmacro -%}
-
-{%- macro sqlserver__is_numeric_dtype(dtype) -%}
-  {% set is_numeric = dtype in ["decimal", "numeric", "bigint" "numeric", "smallint", "decimal", "int", "tinyint", "money", "float", "real"]  %}
-  {% do return(is_numeric) %}
-{%- endmacro -%}
-
 
 {# is_date_or_time_dtype  -------------------------------------------------     #}
 

--- a/macros/cross_db_utils.sql
+++ b/macros/cross_db_utils.sql
@@ -34,6 +34,23 @@
 {%- endmacro -%}
 
 
+{# is_bool_dtype  -------------------------------------------------     #}
+
+{%- macro is_bool_dtype(dtype) -%}
+  {{ return(adapter.dispatch("is_bool_dtype", macro_namespace="dbt_profiler")(dtype)) }}
+{%- endmacro -%}
+
+{%- macro default__is_bool_dtype(dtype) -%}
+  {% set is_bool = dtype.startswith("bool") %}
+  {% do return(is_bool) %}
+{%- endmacro -%}
+
+{%- macro sqlserver__is_numeric_dtype(dtype) -%}
+  {% set is_numeric = dtype in ["decimal", "numeric", "bigint" "numeric", "smallint", "decimal", "int", "tinyint", "money", "float", "real"]  %}
+  {% do return(is_numeric) %}
+{%- endmacro -%}
+
+
 {# is_date_or_time_dtype  -------------------------------------------------     #}
 
 {%- macro is_date_or_time_dtype(dtype) -%}

--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -95,7 +95,7 @@
           {% if "avg" not in exclude_measures -%}
             {% if dbt_profiler.is_numeric_dtype(data_type) %}
                 avg({{ adapter.quote(column_name) }})
-            {% elif dbt_profiler.is_numeric_dtype(data_type) %}
+            {% elif dbt_profiler.is_logical_dtype(data_type) %}
                 avg(case when {{ adapter.quote(column_name) }} then 1 else 0 end)
             {% else %}
                 cast(null as numeric)

--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -93,7 +93,13 @@
             {% if dbt_profiler.is_numeric_dtype(data_type) or dbt_profiler.is_date_or_time_dtype(data_type) %}cast(max({{ adapter.quote(column_name) }}) as {{ dbt_profiler.type_string() }}){% else %}null{% endif %} as max,
           {%- endif %}
           {% if "avg" not in exclude_measures -%}
-            {% if dbt_profiler.is_numeric_dtype(data_type) %}avg({{ adapter.quote(column_name) }}){% else %}cast(null as numeric){% endif %} as avg,
+            {% if dbt_profiler.is_numeric_dtype(data_type) %}
+                avg({{ adapter.quote(column_name) }})
+            {% elif dbt_profiler.is_numeric_dtype(data_type) %}
+                avg(case when {{ adapter.quote(column_name) }} then 1 else 0 end)
+            {% else %}
+                cast(null as numeric)
+            {% endif %} as avg,
           {%- endif %}
           {% if "std_dev_population" not in exclude_measures -%}
             {% if dbt_profiler.is_numeric_dtype(data_type) %}stddev_pop({{ adapter.quote(column_name) }}){% else %}cast(null as numeric){% endif %} as std_dev_population,


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
- I would like to compute the `avg` for `boolean` column with assumption that (True -> 1, False -> 0, null -> 0). 
- I have implemented the function `is_logical_dtype` in `cross_db_utils.sql` macros and also updated the `get_profile.sql`


## Checklist
- [x ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [ x] Postgres
    - [ x] BigQuery
    - [ ] Snowflake
    - [ ] Redshift
    - [ ] SQL Server
    - [ ] Databricks
- [ x] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [ ] I have updated the README.md (if applicable)