### PR TITLE
Change `print_profile_docs` macro now uses the `print` dbt jinja macro instead of `log` for cleaner output (requires dbt version >=1.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ One of the advantages of the `doc` approach over the `meta` approach is that it 
 
 ## Installation
 
-`dbt-profiler` requires dbt version `>=0.19.2`. Check [dbt Hub](https://hub.getdbt.com/data-mie/dbt_profiler/latest/) for the latest installation instructions. 
+`dbt-profiler` requires dbt version `>=1.1.0`. Check [dbt Hub](https://hub.getdbt.com/data-mie/dbt_profiler/latest/) for the latest installation instructions. 
 
 ## Supported adapters
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: "dbt_profiler"
 version: "0.3.0"
 
-require-dbt-version: ">=0.19.2"
+require-dbt-version: ">=1.1.0"
 config-version: 2
 
 target-path: "target"

--- a/macros/print_profile_docs.sql
+++ b/macros/print_profile_docs.sql
@@ -7,9 +7,9 @@
 {% endif %}
 
 {% if execute %}
-  {{ log('{% docs ' + docs_name + '  %}', info=True) }}
+  {{ print('{% docs ' + docs_name + '  %}') }}
   {% do results.print_table(max_rows=max_rows, max_columns=max_columns, max_column_width=max_column_width, max_precision=max_precision) %}
-  {{ log('{% enddocs %}', info=True) }}
+  {{ print('{% enddocs %}') }}
 {% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [x] Postgres
    - [x] BigQuery
    - [ ] Snowflake
    - [ ] Redshift
    - [ ] SQL Server
    - [ ] Databricks
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [x] I have updated the README.md (if applicable)