### PR TITLE
feat: add bigint to is_numeric_dtype

### DIFF
--- a/macros/cross_db_utils.sql
+++ b/macros/cross_db_utils.sql
@@ -24,7 +24,7 @@
 {%- endmacro -%}
 
 {%- macro default__is_numeric_dtype(dtype) -%}
-  {% set is_numeric = dtype.startswith("int") or dtype.startswith("float") or "numeric" in dtype or "number" in dtype or "double" in dtype %}
+  {% set is_numeric = dtype.startswith("int") or dtype.startswith("float") or "numeric" in dtype or "number" in dtype or "double" in dtype or "bigint" in dtype %}
   {% do return(is_numeric) %}
 {%- endmacro -%}
 


### PR DESCRIPTION
This allows the profiler to run against dbt-spark / dbt-databricks profiler

## Description & motivation
add bigint to is_numeric_dtype

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [ ] Postgres
    - [ ] BigQuery
    - [ ] Snowflake
    - [ ] Redshift
    - [ ] SQL Server
    - [x] Databricks
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [ ] I have updated the README.md (if applicable)