### PR TITLE
Use cross-db datatype macro to improve adapter compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,21 +89,24 @@ One of the advantages of the `doc` approach over the `meta` approach is that it 
 
 `dbt-profiler` may work with unsupported adapters but they haven't been tested yet. If you've used `dbt-profiler` with any of the unsupported adapters I'd love to hear your feedback (e.g., create an issue, PR or hit me with with a DM on [dbt Slack](https://community.getdbt.com/)) 😊
 
-✅ PostgreSQL
+✅ AWS Athena
 
 ✅ BigQuery
 
-✅ Snowflake
+✅ Databricks
+
+✅ PostgreSQL
 
 ✅ Redshift
 
-✅ Databricks
+✅ Snowflake
 
 ✅ SQL Server
 
 ❌ Apache Spark
 
 ❌ Presto
+
 
 # Contents
 * [get_profile](#get_profile-source)

--- a/macros/measures.sql
+++ b/macros/measures.sql
@@ -5,7 +5,7 @@
 {%- endmacro -%}
 
 {%- macro default__measure_row_count(column_name, data_type) -%}
-cast(count(*) as numeric)
+cast(count(*) as {{ dbt.type_numeric() }})
 {%- endmacro -%}
 
 
@@ -16,7 +16,7 @@ cast(count(*) as numeric)
 {%- endmacro -%}
 
 {%- macro default__measure_not_null_proportion(column_name, data_type) -%}
-sum(case when {{ adapter.quote(column_name) }} is null then 0 else 1 end) / cast(count(*) as numeric)
+sum(case when {{ adapter.quote(column_name) }} is null then 0 else 1 end) / cast(count(*) as {{ dbt.type_numeric() }})
 {%- endmacro -%}
 
 
@@ -28,9 +28,9 @@ sum(case when {{ adapter.quote(column_name) }} is null then 0 else 1 end) / cast
 
 {%- macro default__measure_distinct_proportion(column_name, data_type) -%}
 {%- if not dbt_profiler.is_struct_dtype(data_type) -%}
-    count(distinct {{ adapter.quote(column_name) }}) / cast(count(*) as numeric)
+    count(distinct {{ adapter.quote(column_name) }}) / cast(count(*) as {{ dbt.type_numeric() }})
 {%- else -%}
-    cast(null as numeric)
+    cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}
 {%- endmacro -%}
 
@@ -44,7 +44,7 @@ sum(case when {{ adapter.quote(column_name) }} is null then 0 else 1 end) / cast
 {%- if not dbt_profiler.is_struct_dtype(data_type) -%}
     count(distinct {{ adapter.quote(column_name) }})
 {%- else -%}
-    cast(null as numeric)
+    cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}
 {%- endmacro -%}
 
@@ -109,7 +109,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 {%- elif dbt_profiler.is_logical_dtype(data_type) -%}
     avg(case when {{ adapter.quote(column_name) }} then 1 else 0 end)
 {%- else -%}
-    cast(null as numeric)
+    cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}
 
 {%- endmacro -%}
@@ -126,7 +126,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 {%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
     stddev_pop({{ adapter.quote(column_name) }})
 {%- else -%}
-    cast(null as numeric)
+    cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}
 
 {%- endmacro -%}
@@ -137,7 +137,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 {%- if dbt_profiler.is_numeric_dtype(data_type) -%}
     stdevp({{ adapter.quote(column_name) }})
 {%- else -%}
-    cast(null as numeric)
+    cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}
 
 {%- endmacro -%}
@@ -155,7 +155,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 {%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
     stddev_samp({{ adapter.quote(column_name) }})
 {%- else -%}
-    cast(null as numeric)
+    cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}
 
 {%- endmacro -%}
@@ -165,7 +165,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 {%- if dbt_profiler.is_numeric_dtype(data_type) -%}
     stdev({{ adapter.quote(column_name) }})
 {%- else -%}
-    cast(null as numeric)
+    cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}
 
 {%- endmacro -%}


### PR DESCRIPTION
## Description & motivation
This permits dbt-profiler to work with the `dbt-athena-community` adapter (and possibly also presto, trino, and spark), by relying on adapter maintainers to implement the [cross-database macros](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros).

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [ ] Postgres
    - [ ] BigQuery
    - [ ] Snowflake
    - [ ] Redshift
    - [ ] SQL Server
    - [ ] Databricks
    - [x] AWS Athena
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [x] I have updated the README.md (if applicable)