### PR TITLE
Add a median measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * `min`*^: Minimum column value
 * `max`*^: Maximum column value
 * `avg`**^: Average column value
+* `median`**^: Median column value
 * `std_dev_population`**^: Population standard deviation
 * `std_dev_sample`**^: Sample standard deviation
 * `profiled_at`: Profile calculation date and time

--- a/integration_tests/models/profile.yml
+++ b/integration_tests/models/profile.yml
@@ -43,7 +43,7 @@ models:
       - name: median
         tests:
           - not_null:
-              where: &column_is_numeric_or_bool column_name not like 'string%' and column_name not like 'date%'
+              where: *column_is_numeric_or_bool
 
       - name: min
         tests:

--- a/integration_tests/models/profile.yml
+++ b/integration_tests/models/profile.yml
@@ -40,6 +40,11 @@ models:
           - not_null:
               where: &column_is_numeric_or_bool column_name not like 'string%' and column_name not like 'date%'
 
+      - name: median
+        tests:
+          - not_null:
+              where: &column_is_numeric_or_bool column_name not like 'string%' and column_name not like 'date%'
+
       - name: min
         tests:
           - not_null:

--- a/integration_tests/models/profile.yml
+++ b/integration_tests/models/profile.yml
@@ -40,11 +40,6 @@ models:
           - not_null:
               where: &column_is_numeric_or_bool column_name not like 'string%' and column_name not like 'date%'
 
-      - name: median
-        tests:
-          - not_null:
-              where: *column_is_numeric_or_bool
-
       - name: min
         tests:
           - not_null:
@@ -61,6 +56,11 @@ models:
               where: &column_is_numeric column_name not like 'string%' and column_name not like 'date%' and column_name not like 'bool%'
 
       - name: std_dev_sample
+        tests:
+          - not_null:
+              where: *column_is_numeric
+
+      - name: median
         tests:
           - not_null:
               where: *column_is_numeric

--- a/integration_tests/models/profile_exclude_measures.sql
+++ b/integration_tests/models/profile_exclude_measures.sql
@@ -1,4 +1,4 @@
 -- depends_on: {{ ref("test_data_default") }}
 {% if execute %}
-  {{ dbt_profiler.get_profile(relation=ref("test_data_default"), exclude_measures=["avg", "std_dev_population", "std_dev_sample"]) }}
+  {{ dbt_profiler.get_profile(relation=ref("test_data_default"), exclude_measures=["avg", "median", "std_dev_population", "std_dev_sample"]) }}
 {% endif %}

--- a/integration_tests/models/profile_exclude_measures.yml
+++ b/integration_tests/models/profile_exclude_measures.yml
@@ -4,5 +4,5 @@ models:
   - name: profile_exclude_measures
     tests:
       - dbt_expectations.expect_table_columns_to_not_contain_set:
-          column_list: ["avg", "std_dev_population", "std_dev_sample"]
+          column_list: ["avg", "median", "std_dev_population", "std_dev_sample"]
           transform: lower

--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -19,6 +19,7 @@
   "min",
   "max",
   "avg",
+  "median",
   "std_dev_population",
   "std_dev_sample"
 ] -%}
@@ -97,6 +98,9 @@
           {%- endif %}
           {% if "avg" not in exclude_measures -%}
             {{ dbt_profiler.measure_avg(column_name, data_type) }} as avg,
+          {%- endif %}
+          {% if "median" not in exclude_measures -%}
+            {{ dbt_profiler.measure_median(column_name, data_type) }} as median,
           {%- endif %}
           {% if "std_dev_population" not in exclude_measures -%}
             {{ dbt_profiler.measure_std_dev_population(column_name, data_type) }} as std_dev_population,
@@ -234,6 +238,9 @@
           {% if "avg" not in exclude_measures -%}
             {{ dbt_profiler.measure_avg(column_name, data_type) }} as avg,
           {%- endif %}
+          {% if "median" not in exclude_measures -%}
+            {{ dbt_profiler.measure_median(column_name, data_type) }} as median,
+          {%- endif %}
           {% if "std_dev_population" not in exclude_measures -%}
             {{ dbt_profiler.measure_std_dev_population(column_name, data_type) }} as std_dev_population,
           {%- endif %}
@@ -366,6 +373,9 @@
           {%- endif %}
           {% if "avg" not in exclude_measures -%}
             {{ dbt_profiler.measure_avg(column_name, data_type) }} as avg,
+          {%- endif %}
+          {% if "median" not in exclude_measures -%}
+            {{ dbt_profiler.measure_median(column_name, data_type) }} as median,
           {%- endif %}
           {% if "std_dev_population" not in exclude_measures -%}
             {{ dbt_profiler.measure_std_dev_population(column_name, data_type) }} as std_dev_population,

--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -154,6 +154,7 @@
   "min",
   "max",
   "avg",
+  "median",
   "std_dev_population",
   "std_dev_sample"
 ] -%}
@@ -295,6 +296,7 @@
   "min",
   "max",
   "avg",
+  "median",
   "std_dev_population",
   "std_dev_sample"
 ] -%}

--- a/macros/measures.sql
+++ b/macros/measures.sql
@@ -134,7 +134,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 {%- macro bigquery__measure_median(column_name, data_type) -%}
 
 {%- if dbt_profiler.is_numeric_dtype(data_type) -%}
-    percentile_disc({{ adapter.quote(column_name) }}, 0.5) over ()
+    APPROX_QUANTILES({{ adapter.quote(column_name) }}, 100)[OFFSET(50)]
 {%- else -%}
     cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}

--- a/macros/measures.sql
+++ b/macros/measures.sql
@@ -123,10 +123,8 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- macro default__measure_median(column_name, data_type) -%}
 
-{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
+{%- if dbt_profiler.is_numeric_dtype(data_type) -%}
     median({{ adapter.quote(column_name) }})
-{%- elif dbt_profiler.is_logical_dtype(data_type) -%}
-    median(case when {{ adapter.quote(column_name) }} then 1 else 0 end)
 {%- else -%}
     cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}
@@ -135,10 +133,8 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- macro bigquery__measure_median(column_name, data_type) -%}
 
-{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
+{%- if dbt_profiler.is_numeric_dtype(data_type) -%}
     percentile_disc({{ adapter.quote(column_name) }}, 0.5) over ()
-{%- elif dbt_profiler.is_logical_dtype(data_type) -%}
-    percentile_disc(case when {{ adapter.quote(column_name) }} then 1 else 0 end, 0.5) over ()
 {%- else -%}
     cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}
@@ -147,10 +143,8 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- macro postgres__measure_median(column_name, data_type) -%}
 
-{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
-    percentile_cont({{ adapter.quote(column_name) }}, 0.5) over ()
-{%- elif dbt_profiler.is_logical_dtype(data_type) -%}
-    percentile_cont(case when {{ adapter.quote(column_name) }} then 1 else 0 end, 0.5) over ()
+{%- if dbt_profiler.is_numeric_dtype(data_type) -%}
+    percentile_cont(0.5) within group (order by {{ adapter.quote(column_name) }})
 {%- else -%}
     cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}
@@ -159,10 +153,8 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- macro sql_server__measure_median(column_name, data_type) -%}
 
-{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
+{%- if dbt_profiler.is_numeric_dtype(data_type) -%}
     percentile_cont({{ adapter.quote(column_name) }}, 0.5) over ()
-{%- elif dbt_profiler.is_logical_dtype(data_type) -%}
-    percentile_cont(case when {{ adapter.quote(column_name) }} then 1 else 0 end, 0.5) over ()
 {%- else -%}
     cast(null as {{ dbt.type_numeric() }})
 {%- endif -%}

--- a/macros/measures.sql
+++ b/macros/measures.sql
@@ -115,6 +115,60 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 {%- endmacro -%}
 
 
+{# measure_median  -------------------------------------------------     #}
+
+{%- macro measure_median(column_name, data_type) -%}
+  {{ return(adapter.dispatch("measure_median", macro_namespace="dbt_profiler")(column_name, data_type)) }}
+{%- endmacro -%}
+
+{%- macro default__measure_median(column_name, data_type) -%}
+
+{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
+    median({{ adapter.quote(column_name) }})
+{%- elif dbt_profiler.is_logical_dtype(data_type) -%}
+    median(case when {{ adapter.quote(column_name) }} then 1 else 0 end)
+{%- else -%}
+    cast(null as {{ dbt.type_numeric() }})
+{%- endif -%}
+
+{%- endmacro -%}
+
+{%- macro bigquery__measure_median(column_name, data_type) -%}
+
+{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
+    percentile_disc({{ adapter.quote(column_name) }}, 0.5) over ()
+{%- elif dbt_profiler.is_logical_dtype(data_type) -%}
+    percentile_disc(case when {{ adapter.quote(column_name) }} then 1 else 0 end, 0.5) over ()
+{%- else -%}
+    cast(null as {{ dbt.type_numeric() }})
+{%- endif -%}
+
+{%- endmacro -%}
+
+{%- macro postgres__measure_median(column_name, data_type) -%}
+
+{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
+    percentile_cont({{ adapter.quote(column_name) }}, 0.5) over ()
+{%- elif dbt_profiler.is_logical_dtype(data_type) -%}
+    percentile_cont(case when {{ adapter.quote(column_name) }} then 1 else 0 end, 0.5) over ()
+{%- else -%}
+    cast(null as {{ dbt.type_numeric() }})
+{%- endif -%}
+
+{%- endmacro -%}
+
+{%- macro sql_server__measure_median(column_name, data_type) -%}
+
+{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
+    percentile_cont({{ adapter.quote(column_name) }}, 0.5) over ()
+{%- elif dbt_profiler.is_logical_dtype(data_type) -%}
+    percentile_cont(case when {{ adapter.quote(column_name) }} then 1 else 0 end, 0.5) over ()
+{%- else -%}
+    cast(null as {{ dbt.type_numeric() }})
+{%- endif -%}
+
+{%- endmacro -%}
+
 {# measure_std_dev_population  -------------------------------------------------     #}
 
 {%- macro measure_std_dev_population(column_name, data_type) -%}

--- a/macros/measures.sql
+++ b/macros/measures.sql
@@ -123,7 +123,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- macro default__measure_median(column_name, data_type) -%}
 
-{%- if dbt_profiler.is_numeric_dtype(data_type) -%}
+{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
     median({{ adapter.quote(column_name) }})
 {%- else -%}
     cast(null as {{ dbt.type_numeric() }})
@@ -133,7 +133,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- macro bigquery__measure_median(column_name, data_type) -%}
 
-{%- if dbt_profiler.is_numeric_dtype(data_type) -%}
+{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
     APPROX_QUANTILES({{ adapter.quote(column_name) }}, 100)[OFFSET(50)]
 {%- else -%}
     cast(null as {{ dbt.type_numeric() }})
@@ -143,7 +143,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- macro postgres__measure_median(column_name, data_type) -%}
 
-{%- if dbt_profiler.is_numeric_dtype(data_type) -%}
+{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
     percentile_cont(0.5) within group (order by {{ adapter.quote(column_name) }})
 {%- else -%}
     cast(null as {{ dbt.type_numeric() }})
@@ -153,7 +153,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- macro sql_server__measure_median(column_name, data_type) -%}
 
-{%- if dbt_profiler.is_numeric_dtype(data_type) -%}
+{%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
     percentile_cont({{ adapter.quote(column_name) }}, 0.5) over ()
 {%- else -%}
     cast(null as {{ dbt.type_numeric() }})


### PR DESCRIPTION
## Description & motivation
Hi @stumelius,

I would like to add a median measurement in profiler because it would be a good indicator when you want to know the skewness simply.<br>
Feel free to discard the PR if you think it not so useful.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [x] Postgres
    - [x] BigQuery
    - [ ] Snowflake
    - [ ] Redshift
    - [ ] SQL Server
    - [ ] Databricks
- [x] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [x] I have updated the README.md (if applicable)