### PR TITLE
Search for `docs` blocks within the `"docs"` directory (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ For the third point there are at least two options:
 
 An example of the first is implemented in the [print_profile_schema](#print_profile_schema-source) macro. The second can be achieved with the following pattern:
 
+0. Add a `"docs"` folder explicitly to `dbt_project.yml` via [`model-paths`](https://docs.getdbt.com/reference/project-configs/model-paths)
+```
+model-paths: ["models", "docs"]
+```
 1. Use [print_profile_docs](#print_profile_docs-source) macro to generate the profile as a Markdown table wrapped in a Jinja `docs` macro
 2. Copy the output to a `docs/dbt_profiler/<model>.md` file
 ```


### PR DESCRIPTION
resolves #71

## Description & motivation

The `dbt_profiler` dbt package generates `docs` blocks that are written into the `docs/dbt_profiler` directory.

But "docs" isn't included in the [default for `docs-paths`](https://docs.getdbt.com/reference/project-configs/docs-paths#default), so the `"docs"` folder needs to be explicitly added to `dbt_project.yml` either via [`model-paths`](https://docs.getdbt.com/reference/project-configs/model-paths) or [`docs-paths`](https://docs.getdbt.com/reference/project-configs/docs-paths).

### Suggested approach to enable `docs/dbt_profiler` folder

There are two main options:
1. Override `model-paths`
1. Override `docs-paths`

Overriding `model-paths` to be `["models", "docs"]` (or extending it to add "docs") will "always work".

This is because [by default](https://docs.getdbt.com/reference/project-configs/docs-paths#default), dbt will search in all resource paths for docs blocks (i.e. the combined list of [model-paths](https://docs.getdbt.com/reference/project-configs/model-paths), [seed-paths](https://docs.getdbt.com/reference/project-configs/seed-paths), [analysis-paths](https://docs.getdbt.com/reference/project-configs/analysis-paths), [macro-paths](https://docs.getdbt.com/reference/project-configs/macro-paths) and [snapshot-paths](https://docs.getdbt.com/reference/project-configs/snapshot-paths)).

However, overriding `docs-paths` instead could have unintended side-effects if the dbt project has pre-existing `docs` blocks within their `model-paths`, `seed-paths`, `analysis-paths`, `macro-paths` and/or `snapshot-paths`.

So I'd recommend going the `model-paths` route rather than the `docs-paths` route.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses:
    - [x] DuckDB
- [x] No new tests are needed for this PR
- [x] I have updated the README.md (if applicable)