### PR TITLE
Fix. Issue 84. Median function fixed for Redshift

### DIFF
--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -100,7 +100,7 @@
             {{ dbt_profiler.measure_avg(column_name, data_type) }} as avg,
           {%- endif %}
           {% if "median" not in exclude_measures -%}
-            {{ dbt_profiler.measure_median(column_name, data_type) }} as median,
+            ({{ dbt_profiler.measure_median(column_name, data_type, 'source_data') }}) as median,
           {%- endif %}
           {% if "std_dev_population" not in exclude_measures -%}
             {{ dbt_profiler.measure_std_dev_population(column_name, data_type) }} as std_dev_population,
@@ -240,7 +240,7 @@
             {{ dbt_profiler.measure_avg(column_name, data_type) }} as avg,
           {%- endif %}
           {% if "median" not in exclude_measures -%}
-            {{ dbt_profiler.measure_median(column_name, data_type) }} as median,
+            ({{ dbt_profiler.measure_median(column_name, data_type, 'source_data') }}) as median,
           {%- endif %}
           {% if "std_dev_population" not in exclude_measures -%}
             {{ dbt_profiler.measure_std_dev_population(column_name, data_type) }} as std_dev_population,
@@ -377,7 +377,7 @@
             {{ dbt_profiler.measure_avg(column_name, data_type) }} as avg,
           {%- endif %}
           {% if "median" not in exclude_measures -%}
-            {{ dbt_profiler.measure_median(column_name, data_type) }} as median,
+            ({{ dbt_profiler.measure_median(column_name, data_type, 'source_data') }}) as median,
           {%- endif %}
           {% if "std_dev_population" not in exclude_measures -%}
             {{ dbt_profiler.measure_std_dev_population(column_name, data_type) }} as std_dev_population,


### PR DESCRIPTION
## Description & motivation
<!---
Median function and some other aggregate types won't work in context of distinct (per #84). Note, there is no new macro, so no tests to write, or need to update the README. There is nothing new the user needs to do, other than what is already listed in the documentation for dbt-profiler.
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [ ] Postgres
    - [ ] BigQuery
    - [ ] Snowflake
    - [x] Redshift
    - [ ] SQL Server
    - [ ] Databricks
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [ ] I have updated the README.md (if applicable)