### PR TITLE
Fix median calculation in Redshift

### DIFF
--- a/macros/get_profile.sql
+++ b/macros/get_profile.sql
@@ -100,7 +100,7 @@
             {{ dbt_profiler.measure_avg(column_name, data_type) }} as avg,
           {%- endif %}
           {% if "median" not in exclude_measures -%}
-            {{ dbt_profiler.measure_median(column_name, data_type) }} as median,
+            ({{ dbt_profiler.measure_median(column_name, data_type, 'source_data') }}) as median,
           {%- endif %}
           {% if "std_dev_population" not in exclude_measures -%}
             {{ dbt_profiler.measure_std_dev_population(column_name, data_type) }} as std_dev_population,
@@ -240,7 +240,7 @@
             {{ dbt_profiler.measure_avg(column_name, data_type) }} as avg,
           {%- endif %}
           {% if "median" not in exclude_measures -%}
-            {{ dbt_profiler.measure_median(column_name, data_type) }} as median,
+            ({{ dbt_profiler.measure_median(column_name, data_type, 'source_data') }}) as median,
           {%- endif %}
           {% if "std_dev_population" not in exclude_measures -%}
             {{ dbt_profiler.measure_std_dev_population(column_name, data_type) }} as std_dev_population,
@@ -377,7 +377,7 @@
             {{ dbt_profiler.measure_avg(column_name, data_type) }} as avg,
           {%- endif %}
           {% if "median" not in exclude_measures -%}
-            {{ dbt_profiler.measure_median(column_name, data_type) }} as median,
+            ({{ dbt_profiler.measure_median(column_name, data_type, 'source_data') }}) as median,
           {%- endif %}
           {% if "std_dev_population" not in exclude_measures -%}
             {{ dbt_profiler.measure_std_dev_population(column_name, data_type) }} as std_dev_population,

--- a/macros/measures.sql
+++ b/macros/measures.sql
@@ -133,7 +133,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
   {{ return(adapter.dispatch("measure_median", macro_namespace="dbt_profiler")(column_name, data_type, cte_name)) }}
 {%- endmacro -%}
 
-{%- macro default__measure_median(column_name, data_type) -%}
+{%- macro default__measure_median(column_name, data_type, cte_name) -%}
 
 {%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
     median({{ adapter.quote(column_name) }})
@@ -143,7 +143,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- endmacro -%}
 
-{%- macro bigquery__measure_median(column_name, data_type) -%}
+{%- macro bigquery__measure_median(column_name, data_type, cte_name) -%}
 
 {%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
     APPROX_QUANTILES({{ adapter.quote(column_name) }}, 100)[OFFSET(50)]
@@ -153,7 +153,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- endmacro -%}
 
-{%- macro postgres__measure_median(column_name, data_type) -%}
+{%- macro postgres__measure_median(column_name, data_type, cte_name) -%}
 
 {%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
     percentile_cont(0.5) within group (order by {{ adapter.quote(column_name) }})
@@ -173,7 +173,7 @@ case when count(distinct {{ adapter.quote(column_name) }}) = count(*) then 1 els
 
 {%- endmacro -%}
 
-{%- macro sql_server__measure_median(column_name, data_type) -%}
+{%- macro sql_server__measure_median(column_name, data_type, cte_name) -%}
 
 {%- if dbt_profiler.is_numeric_dtype(data_type) and not dbt_profiler.is_struct_dtype(data_type) -%}
     percentile_cont({{ adapter.quote(column_name) }}, 0.5) over ()


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Median function and some other aggregate types won't work in context of distinct (per #84 ). Note, there is no new macro, so no tests to write, or need to update the README. There is nothing new the user needs to do, other than what is already listed in the documentation for dbt-profiler.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [ ] Postgres
    - [ ] BigQuery
    - [ ] Snowflake
    - [x] Redshift
    - [ ] SQL Server
    - [ ] Databricks
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [ ] I have updated the README.md (if applicable)