### PR TITLE
refactor(measures.sql): set `row_count` type as `int`

### DIFF
--- a/macros/measures.sql
+++ b/macros/measures.sql
@@ -5,7 +5,7 @@
 {%- endmacro -%}
 
 {%- macro default__measure_row_count(column_name, data_type) -%}
-cast(count(*) as {{ dbt.type_numeric() }})
+cast(count(*) as {{ dbt.type_int() }})
 {%- endmacro -%}
 
 


### PR DESCRIPTION
## Description & motivation
Show `row_count` as `int`

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [x] Postgres
    - [x] BigQuery
    - [x] Snowflake
    - [ ] Redshift
    - [ ] SQL Server
    - [ ] Databricks
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [ ] I have updated the README.md (if applicable)