### PR TITLE
Add an athena__is_numeric_dtype macro

### DIFF
--- a/macros/cross_db_utils.sql
+++ b/macros/cross_db_utils.sql
@@ -33,6 +33,10 @@
   {% do return(is_numeric) %}
 {%- endmacro -%}
 
+{%- macro athena__is_numeric_dtype(dtype) -%}
+  {% set is_numeric = "int" in dtype or "float" in dtype or "decimal" in dtype or "double" in dtype %}
+  {% do return(is_numeric) %}
+{%- endmacro -%}
 
 {# is_logical_dtype  -------------------------------------------------     #}
 


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

https://docs.aws.amazon.com/ja_jp/athena/latest/ug/data-types.html

Athena has various numeric data types, which the dbt-profiler doesn't consider they are numeric, so I added a is_numeric_dtype macro dedicated for Athena. Then, we can calculate min/max and the other profiles of those data types such as decimal.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [ ] Postgres
    - [ ] BigQuery
    - [ ] Snowflake
    - [ ] Redshift
    - [ ] SQL Server
    - [ ] Databricks
    - [x] Athena
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [ ] I have updated the README.md (if applicable)