### PR TITLE
Use bigint for counts

### DIFF
--- a/macros/measures.sql
+++ b/macros/measures.sql
@@ -5,7 +5,7 @@
 {%- endmacro -%}
 
 {%- macro default__measure_row_count(column_name, data_type) -%}
-cast(count(*) as {{ dbt.type_int() }})
+cast(count(*) as {{ dbt.type_bigint() }})
 {%- endmacro -%}
 
 


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

My table has so many records and int is too small for the count column. Could you consider using bigint?

<img width="572" alt="Screenshot 2024-11-08 at 12 58 09" src="https://github.com/user-attachments/assets/491180ef-f4d0-41e4-95cc-f0efbe4e649a">


## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered):
    - [ ] Postgres
    - [ ] BigQuery
    - [ ] Snowflake
    - [ ] Redshift
    - [ ] SQL Server
    - [ ] Databricks
- [ ] I have written tests for new macros (either as dbt schema tests in `integration_tests/models`, dbt data tests in `integration_tests/tests` or integration tests in the [CI workflow](workflows/main.yml))
- [ ] I have updated the README.md (if applicable)